### PR TITLE
Add hagl_begin() and hagl_end() hint functions

### DIFF
--- a/include/hagl.h
+++ b/include/hagl.h
@@ -73,6 +73,8 @@ extern "C" {
 
 hagl_backend_t *hagl_init(void);
 size_t hagl_flush(hagl_backend_t *backend);
+void hagl_begin(hagl_backend_t *backend);
+void hagl_end(hagl_backend_t *backend);
 void hagl_close(hagl_backend_t *backend);
 
 void hagl_clear(void *surface);

--- a/include/hagl/backend.h
+++ b/include/hagl/backend.h
@@ -61,6 +61,8 @@ typedef struct {
 
     /* Specific to backend. */
     size_t (*flush)(void *self);
+    void (*begin)(void *self);
+    void (*end)(void *self);
     void (*close)(void *self);
     uint8_t *buffer;
     uint8_t *buffer2;

--- a/src/hagl.c
+++ b/src/hagl.c
@@ -85,6 +85,22 @@ hagl_flush(hagl_backend_t *backend)
 };
 
 void
+hagl_begin(hagl_backend_t *backend)
+{
+    if (backend->begin) {
+        backend->begin(backend);
+    }
+};
+
+void
+hagl_end(hagl_backend_t *backend)
+{
+    if (backend->end) {
+        backend->end(backend);
+    }
+};
+
+void
 hagl_close(hagl_backend_t *backend)
 {
     if (backend->close) {


### PR DESCRIPTION
Add hint functions that allow draw calls to be grouped. This provides a hint to the backend implementation that drawing has potentially started or ended. Useful for tasks such as acquiring the SPI bus when in single buffered mode. 

See: https://github.com/saawsm/hagl_esp_mipi/pull/2 